### PR TITLE
Added VirtualizedUniformGrid to speed up loading

### DIFF
--- a/BLREdit/UI/Controls/ItemListControl.xaml
+++ b/BLREdit/UI/Controls/ItemListControl.xaml
@@ -6,10 +6,11 @@
              xmlns:local="clr-namespace:BLREdit.UI.Controls"
              xmlns:import="clr-namespace:BLREdit.Import"
              d:DataContext="{d:DesignInstance Type=import:BLRItem}"
-             mc:Ignorable="d" >
+             mc:Ignorable="d"
+             MinWidth="285">
     <VirtualizingStackPanel Orientation="Vertical" Background="Transparent" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="-4,-1,-4,-1" ToolTip="{Binding Tooltip}" MouseDown="ItemList_MouseDown">
         <Border BorderThickness="1,1,1,1">
-            <Image Source="{Binding WideImage, IsAsync=True}" HorizontalAlignment="Center" VerticalAlignment="Top" Stretch="None" />
+            <Image Source="{Binding WideImage, IsAsync=True}" HorizontalAlignment="Center" VerticalAlignment="Top" Stretch="None" Width="256" Height="128" />
         </Border>
         <Image Source="{Binding Crosshair, IsAsync=True}" HorizontalAlignment="Center" VerticalAlignment="Top" Stretch="UniformToFill" MaxWidth="1280" MaxHeight="720" />
         <Border BorderThickness="1,0,1,1">
@@ -17,7 +18,7 @@
         </Border>
         <Border BorderThickness="1,0,1,1">
             <UniformGrid Columns="3">
-                <UniformGrid Columns="2">
+                <StackPanel Orientation="Horizontal">
                     <Label Content="{Binding Path=DisplayStat1.Description}" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Label.Style>
                             <Style>
@@ -32,9 +33,9 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                </UniformGrid>
+                </StackPanel>
 
-                <UniformGrid Columns="2">
+                <StackPanel Orientation="Horizontal">
                     <Label Content="{Binding DisplayStat2.Description}" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Label.Style>
                             <Style>
@@ -49,9 +50,9 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                </UniformGrid>
+                </StackPanel>
 
-                <UniformGrid Columns="2">
+                <StackPanel Orientation="Horizontal">
                     <Label Content="{Binding DisplayStat3.Description}" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Label.Style>
                             <Style>
@@ -66,9 +67,9 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                </UniformGrid>
+                </StackPanel>
 
-                <UniformGrid Columns="2">
+                <StackPanel Orientation="Horizontal">
                     <Label Content="{Binding DisplayStat4.Description}" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Label.Style>
                             <Style>
@@ -83,9 +84,9 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                </UniformGrid>
+                </StackPanel>
 
-                <UniformGrid Columns="2">
+                <StackPanel Orientation="Horizontal">
                     <Label Content="{Binding DisplayStat5.Description}" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Label.Style>
                             <Style>
@@ -100,9 +101,9 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                </UniformGrid>
+                </StackPanel>
 
-                <UniformGrid Columns="2">
+                <StackPanel Orientation="Horizontal">
                     <Label Content="{Binding DisplayStat6.Description}" HorizontalAlignment="Right" VerticalAlignment="Center">
                         <Label.Style>
                             <Style>
@@ -117,7 +118,7 @@
                             </Style>
                         </Label.Style>
                     </Label>
-                </UniformGrid>
+                </StackPanel>
 
             </UniformGrid>
         </Border>

--- a/BLREdit/UI/Controls/VirtualizedUniformGrid.cs
+++ b/BLREdit/UI/Controls/VirtualizedUniformGrid.cs
@@ -1,0 +1,424 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+
+namespace BLREdit.UI.Controls
+{
+    public class VirtualizedUniformGrid : VirtualizingPanel, IScrollInfo
+    {
+        private Size _extent = new Size(0, 0);
+        private Size _viewport = new Size(0, 0);
+        private Point _offset = new Point(0, 0);
+        private bool _canHorizontallyScroll = true;
+        private bool _canVerticallyScroll = true;
+        private ScrollViewer _owner;
+        private int _scrollLength = 25;
+        private Size _itemSize = new Size(0, 0);
+
+        public static readonly DependencyProperty OrientationProperty = DependencyProperty.RegisterAttached("Orientation", typeof(Orientation), typeof(UniformGridPanel),
+            new FrameworkPropertyMetadata(Orientation.Vertical, FrameworkPropertyMetadataOptions.AffectsArrange | FrameworkPropertyMetadataOptions.AffectsMeasure));
+
+        private int _rows;
+        private int _columns;
+
+        public Orientation Orientation
+        {
+            get { return (Orientation)GetValue(OrientationProperty); }
+            set { SetValue(OrientationProperty, value); }
+        }
+
+        public VirtualizedUniformGrid()
+        {
+        }
+
+        private static bool ValidateFirstColumn(object o)
+        {
+            return (int)o >= 0;
+        }
+
+        #region VirtualizingPanel Overrides
+
+        protected override Size MeasureOverride(Size constraint)
+        {
+            UpdateComputedValues();
+            UpdateScrollInfo(constraint);
+            Size availableSize = constraint;
+
+            ItemsControl itemsControl = ItemsControl.GetItemsOwner(this);
+            int itemCount = itemsControl.HasItems ? itemsControl.Items.Count : 0;
+
+            int firstVisibleItemIndex, lastVisibleItemIndex;
+            GetVisibleRange(out firstVisibleItemIndex, out lastVisibleItemIndex);
+
+            firstVisibleItemIndex = Math.Min(Math.Max(firstVisibleItemIndex, 0), itemCount - 1);
+            lastVisibleItemIndex = Math.Min(Math.Max(lastVisibleItemIndex, 0), itemCount - 1);
+
+            UIElementCollection children = InternalChildren;
+            IItemContainerGenerator generator = ItemContainerGenerator;
+
+            GeneratorPosition startPos = generator.GeneratorPositionFromIndex(firstVisibleItemIndex);
+
+            int childIndex = startPos.Offset == 0 ? startPos.Index : startPos.Index + 1;
+
+            using (generator.StartAt(startPos, GeneratorDirection.Forward, true))
+            {
+                for (int itemIndex = firstVisibleItemIndex; itemIndex <= lastVisibleItemIndex; ++itemIndex, ++childIndex)
+                {
+                    bool newlyRealized;
+
+                    UIElement child = generator.GenerateNext(out newlyRealized) as UIElement;
+
+                    childIndex = Math.Max(0, childIndex);
+
+                    if (newlyRealized)
+                    {
+                        if (childIndex >= children.Count)
+                        {
+                            AddInternalChild(child);
+                        }
+                        else
+                        {
+                            InsertInternalChild(childIndex, child);
+                        }
+
+                        generator.PrepareItemContainer(child);
+                    }
+                    else
+                    {
+                        Debug.Assert(child == children[childIndex], "Wrong child was generated");
+                    }
+                }
+            }
+
+            foreach (UIElement element in base.InternalChildren)
+            {
+                element.Measure(availableSize);
+                if (element != null)
+                {
+                    element.Measure(availableSize);
+                }
+            }
+
+            UpdateComputedValues();
+
+            return new Size(0, 0);
+        }
+
+        protected override Size ArrangeOverride(Size arrangeSize)
+        {
+            IItemContainerGenerator generator = ItemContainerGenerator;
+
+            for (int i = 0; i < Children.Count; i++)
+            {
+                UIElement child = Children[i];
+
+                int itemIndex = generator.IndexFromGeneratorPosition(new GeneratorPosition(i, 0));
+
+                ArrangeChild(itemIndex, child);
+            }
+            return arrangeSize;
+        }
+
+        #endregion VirtualizingPanel Overrides
+
+        private void ArrangeChild(int index, UIElement child)
+        {
+            if (_rows == 0 || _columns == 0) return;
+
+            double xPosition, yPosition;
+            Size childSize = child.DesiredSize;
+
+            if (Orientation == Orientation.Horizontal)
+            {
+                int row = index % _rows;
+                int column = index / _rows;
+                xPosition = column * childSize.Width - _offset.X;
+                yPosition = row * childSize.Height - _offset.Y;
+            }
+            else
+            {
+                int row = index / _columns;
+                int column = index % _columns;
+                xPosition = column * childSize.Width - _offset.X;
+                yPosition = row * childSize.Height - _offset.Y;
+            }
+
+            child.Arrange(new Rect(xPosition, yPosition, childSize.Width, childSize.Height));
+        }
+
+        private void UpdateComputedValues()
+        {
+            UIElement child;
+            Size childSize = new Size();
+            if (base.InternalChildren.Count != 0)
+            {
+                child = base.InternalChildren[0];
+                childSize = child.DesiredSize;
+            }
+
+            if (childSize.Width == 0 || childSize.Height == 0)
+                return;
+
+            _itemSize = childSize;
+
+            _columns = (int)Math.Floor(_viewport.Width / childSize.Width);
+            _rows = (int)Math.Floor(_viewport.Height / childSize.Height);
+
+            _scrollLength = Orientation == Orientation.Horizontal ?
+                (int)childSize.Width / 2 :
+                (int)childSize.Height / 2;
+
+            UpdateScrollInfo(_viewport);
+            return;
+        }
+
+        private Size MeasureExtent(Size availableSize, int itemsCount)
+        {
+            Size childSize = _itemSize;
+
+            if (Orientation == Orientation.Horizontal)
+            {
+                var rowWidth = childSize.Width;
+
+                var sizeWidth = rowWidth * Math.Ceiling(((double)itemsCount / _rows));
+                var sizeHeight = childSize.Height * _rows;
+
+                return new Size(sizeWidth, sizeHeight);
+            }
+            else
+            {
+                var rowHeight = childSize.Height;
+
+                var sizeWidth = childSize.Width * _columns;
+                var sizeHeight = rowHeight * Math.Ceiling(((double)itemsCount / _columns));
+
+                return new Size(sizeWidth, sizeHeight);
+            }
+        }
+
+        private void GetVisibleRange(out int firstVisibleItemIndex, out int lastVisibleItemIndex)
+        {
+            Size childSize = _itemSize;
+
+            int pageSize = _columns * _rows;
+
+            if (Orientation == Orientation.Horizontal)
+            {
+                int currentColumn = (int)Math.Floor(_offset.X / childSize.Width);
+
+                firstVisibleItemIndex = currentColumn * _rows;
+                lastVisibleItemIndex = firstVisibleItemIndex + pageSize + 2 * _rows - 1;
+            }
+            else
+            {
+                int currentRow = (int)Math.Floor(_offset.Y / childSize.Height);
+
+                firstVisibleItemIndex = currentRow * _columns;
+                lastVisibleItemIndex = firstVisibleItemIndex + pageSize + 2 * _columns - 1;
+            }
+        }
+
+        #region IScrollInfo Implementation
+
+        public bool CanHorizontallyScroll
+        {
+            get { return _canHorizontallyScroll; }
+            set { _canHorizontallyScroll = value; }
+        }
+
+        public bool CanVerticallyScroll
+        {
+            get { return _canVerticallyScroll; }
+            set { _canVerticallyScroll = value; }
+        }
+
+        public double ExtentHeight
+        {
+            get { return _extent.Height; }
+        }
+
+        public double ExtentWidth
+        {
+            get { return _extent.Width; }
+        }
+
+        public double HorizontalOffset
+        {
+            get { return _offset.X; }
+        }
+
+        public double VerticalOffset
+        {
+            get { return _offset.Y; }
+        }
+
+        public ScrollViewer ScrollOwner
+        {
+            get { return _owner; }
+            set { _owner = value; }
+        }
+
+        public double ViewportHeight
+        {
+            get { return _viewport.Height; }
+        }
+
+        public double ViewportWidth
+        {
+            get { return _viewport.Width; }
+        }
+
+        public void LineLeft()
+        {
+            SetHorizontalOffset(_offset.X - _scrollLength);
+        }
+
+        public void LineRight()
+        {
+            SetHorizontalOffset(_offset.X + _scrollLength);
+        }
+
+        public void LineUp()
+        {
+            SetVerticalOffset(_offset.Y - _scrollLength);
+        }
+
+        public void LineDown()
+        {
+            SetVerticalOffset(_offset.Y + _scrollLength);
+        }
+
+        public Rect MakeVisible(System.Windows.Media.Visual visual, Rect rectangle)
+        {
+            return new Rect();
+        }
+
+        public void MouseWheelDown()
+        {
+            if (Orientation == Orientation.Horizontal)
+            {
+                SetHorizontalOffset(_offset.X + _scrollLength);
+            }
+            else
+            {
+                SetVerticalOffset(_offset.Y + _scrollLength);
+            }
+        }
+
+        public void MouseWheelUp()
+        {
+            if (Orientation == Orientation.Horizontal)
+            {
+                SetHorizontalOffset(_offset.X - _scrollLength);
+            }
+            else
+            {
+                SetVerticalOffset(_offset.Y - _scrollLength);
+            }
+        }
+
+        public void MouseWheelLeft()
+        {
+            return;
+        }
+
+        public void MouseWheelRight()
+        {
+            return;
+        }
+
+        public void PageDown()
+        {
+            SetVerticalOffset(_offset.Y + _viewport.Width);
+        }
+
+        public void PageUp()
+        {
+            SetVerticalOffset(_offset.Y - _viewport.Width);
+        }
+
+        public void PageLeft()
+        {
+            SetHorizontalOffset(_offset.X - _viewport.Width);
+        }
+
+        public void PageRight()
+        {
+            SetHorizontalOffset(_offset.X + _viewport.Width);
+        }
+
+        public void SetHorizontalOffset(double offset)
+        {
+            if (offset > _extent.Width - _viewport.Width)
+            {
+                offset = _extent.Width - _viewport.Width;
+            }
+            offset = Math.Max(0, offset);
+
+            if (_offset.X == offset)
+                return;
+
+            _offset.X = offset;
+
+            if (_owner != null)
+            {
+                _owner.InvalidateScrollInfo();
+            }
+
+            InvalidateMeasure();
+        }
+
+        public void SetVerticalOffset(double offset)
+        {
+            if (offset > _extent.Height - _viewport.Height)
+            {
+                offset = _extent.Height - _viewport.Height;
+            }
+            offset = Math.Max(0, offset);
+
+            if (_offset.Y == offset)
+                return;
+
+            _offset.Y = offset;
+            if (_owner != null)
+            {
+                _owner.InvalidateScrollInfo();
+            }
+
+            InvalidateMeasure();
+        }
+
+        private void UpdateScrollInfo(Size availableSize)
+        {
+            ItemsControl itemsControl = ItemsControl.GetItemsOwner(this);
+            int itemCount = itemsControl.HasItems ? itemsControl.Items.Count : 0;
+
+            Size extent = MeasureExtent(availableSize, itemCount);
+            if (extent != _extent)
+            {
+                _extent = extent;
+                _offset = new Point();
+                if (_owner != null)
+                    _owner.InvalidateScrollInfo();
+            }
+
+            if (availableSize != _viewport)
+            {
+                _viewport = availableSize;
+                if (_owner != null)
+                    _owner.InvalidateScrollInfo();
+            }
+
+        }
+
+        #endregion IScrollInfo Implementation
+
+    }
+}

--- a/BLREdit/UI/Windows/MainWindow.xaml
+++ b/BLREdit/UI/Windows/MainWindow.xaml
@@ -41,7 +41,7 @@
                 <Grid>
                     <Button Name="SortDirectionButton" Content="Descending" HorizontalAlignment="Left" VerticalAlignment="Top" Width="120" Height="22"  Click="ChangeSortingDirection"/>
                     <ComboBox Name="SortComboBox1" HorizontalAlignment="Left" VerticalAlignment="Top" Width="120" Height="22" Margin="120,0,0,0" SelectionChanged="SortComboBox1_SelectionChanged"/>
-                    <ListView Name="ItemList" Margin="0,22,0,0" Grid.ColumnSpan="2">
+                    <ListView Name="ItemList" Margin="0,22,0,0" Grid.ColumnSpan="2" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.HorizontalScrollBarVisibility="Auto">
                         <ListView.ItemContainerStyle>
                             <Style TargetType="ListViewItem">
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
@@ -52,7 +52,7 @@
                         </ListView.ItemContainerStyle>
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <UniformGrid HorizontalAlignment="Left" VerticalAlignment="Top" Columns="{Binding Path=Columns, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=old:MainWindow}}"/>
+                                <ui:VirtualizedUniformGrid Orientation="Vertical" HorizontalAlignment="Left" VerticalAlignment="Top" />
                             </ItemsPanelTemplate>
                         </ItemsControl.ItemsPanel>
                         <ListView.ItemTemplate>


### PR DESCRIPTION
I noticed loading all the items in the item lists take a while so I created this virtualized panel which loads the items as they become visible. Columns and rows are calculated automatically and the Orientation property decides which way the list scrolls.

Changed UniformGrids in ItemListControl to StackPanel to save horizontal space. Added Width and Height to Image so element size doesn't change too much after image gets loaded. Added MinWidth to fix issue where element widths weren't the same.

Note, this is my first time creating a WPF panel, so it's probably not well made but as far as I know, it works. You can probably find a better implementation on Google.