### PR TITLE
Added a command line argument to start a server

### DIFF
--- a/BLREdit/App.xaml
+++ b/BLREdit/App.xaml
@@ -2,7 +2,8 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:BLREdit"
-             StartupUri="UI/Windows/MainWindow.xaml">
+             StartupUri="UI/Windows/MainWindow.xaml"
+             Startup="Application_Startup">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/BLREdit/App.xaml.cs
+++ b/BLREdit/App.xaml.cs
@@ -41,6 +41,45 @@ public partial class App : System.Windows.Application
 
     private const string LogFile = "log.txt";
     public static readonly string BLREditLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "\\";
+    private void Application_Startup(object sender, StartupEventArgs e)
+    {
+        string[] argList = e.Args;
+        Dictionary<string, string> argDict = new();
+
+        for(var i = 0; i < argList.Length; i++)
+        {
+            string name = argList[i];
+            string value = "";
+            if (!name.StartsWith("-")) continue;
+            if (i+1 < argList.Length && !argList[i + 1].StartsWith("-")) value = argList[i+1];
+            argDict.Add(name, value);
+        }
+
+        if (argDict.TryGetValue("-server", out string configFile))
+        {
+            try
+            {
+                var serverConfig = IOResources.DeserializeFile<ServerLaunchParameters>(configFile);
+
+                var client = UI.MainWindow.GameClients[serverConfig.ClientId];
+
+                var serverName = serverConfig.ServerName;
+                var port = serverConfig.Port;
+                var botCount = serverConfig.BotCount;
+                var maxPlayers = serverConfig.MaxPlayers;
+                var playlist = serverConfig.Playlist;
+
+                string launchArgs = $"server ?ServerName=\"{serverName}\"?Port={port}?NumBots={botCount}?MaxPlayers={maxPlayers}?Playlist={playlist}";
+                client.StartProcess(launchArgs);
+
+                Application.Current.Shutdown();
+            }
+            catch (Exception error)
+            { 
+                LoggingSystem.MessageLog($"failed to start server:\n{error}"); 
+            }
+        }
+    }
 
     public App()
     {

--- a/BLREdit/Game/BLRClient.cs
+++ b/BLREdit/Game/BLRClient.cs
@@ -377,7 +377,7 @@ public sealed class BLRClient : INotifyPropertyChanged
         launchArgs += $"?Name={options.UserName}";
         StartProcess(launchArgs);
     }
-    private void StartProcess(string launchArgs)
+    public void StartProcess(string launchArgs)
     {
         if (!hasBeenValidated)
         {

--- a/BLREdit/Game/ServerLaunchParameters.cs
+++ b/BLREdit/Game/ServerLaunchParameters.cs
@@ -1,0 +1,12 @@
+﻿namespace BLREdit.Game
+{
+    internal class ServerLaunchParameters
+    {
+        public int ClientId = 0;
+        public string ServerName = "Custom Server";
+        public string Playlist = "DM";
+        public int Port = 7777;
+        public int BotCount = 2;
+        public int MaxPlayers = 16;
+    }
+}

--- a/BLREdit/example_server_config.json
+++ b/BLREdit/example_server_config.json
@@ -1,0 +1,8 @@
+{
+    "ClientId": 0,
+    "ServerName": "My Server",
+    "Playlist": "CTF",
+    "Port": 7777,
+    "BotCount": 4,
+    "MaxPlayers": 16
+}


### PR DESCRIPTION
Added the -server command line argument that starts up a server using a config file and closes BLREdit.

Usage:
BLREdit.exe -server <config_path>

Example:
BLREdit.exe -server ./server_config.json

Check example_server_config.json for an example config.