### PR TITLE
Implemented handling for non Magi servers

### DIFF
--- a/BLREdit/API/REST_API/Server/ServerUtilsInfo.cs
+++ b/BLREdit/API/REST_API/Server/ServerUtilsInfo.cs
@@ -7,6 +7,7 @@ namespace BLREdit.API.REST_API.Server;
 
 public sealed class ServerUtilsInfo
 {
+    public bool IsOnline { get; set; } = false;
     public int BotCount { get; set; } = 0;
     public string GameMode { get; set; } = "DM";
     [JsonIgnore] public string ModeName { get { return GameMode.ToUpper(); } set { } }

--- a/BLREdit/Game/BLRServer.cs
+++ b/BLREdit/Game/BLRServer.cs
@@ -33,7 +33,7 @@ public sealed class BLRServer : INotifyPropertyChanged
     [JsonIgnore] public bool IsDefaultServer { get { return Equals(BLREditSettings.Settings.DefaultServer); } set { IsNotDefaultServer = value; OnPropertyChanged(); } }
     [JsonIgnore] public bool IsNotDefaultServer { get { return !IsDefaultServer; } set { OnPropertyChanged(); } }
     [JsonIgnore] public string PingDisplay { get { if (IsOnline) { return "Online"; } else { return "Offline"; } } }
-    [JsonIgnore] public bool IsOnline { get { return MagiInfo?.IsOnline ?? false; } }
+    [JsonIgnore] public bool IsOnline { get { return ((ServerInfo?.IsOnline ?? false) || (MagiInfo?.IsOnline ?? false)); } }
 
     private readonly UIBool isPinging = new(false);
     [JsonIgnore] public UIBool IsPinging { get { return isPinging; } }
@@ -114,7 +114,7 @@ public sealed class BLRServer : INotifyPropertyChanged
         var server = ServerUtilsClient.GetServerInfo(this);
         server.Wait();
         ServerInfo = server.Result;
-        if (ServerInfo is null) { ServerInfo = new(); } else { LoggingSystem.Log($"[Server]({ServerAddress}): got Server Info!"); }
+        if (ServerInfo is null) { ServerInfo = new(); } else { ServerInfo.IsOnline = true; LoggingSystem.Log($"[Server]({ServerAddress}): got Server Info!"); }
 
         var magi = MagiCowClient.GetServerInfo(ServerAddress);
         magi.Wait();


### PR DESCRIPTION
Current code causes servers using the server-utils module to always show as offline. 

This PR will fix that behavior while leaving behind compatibility for the MagiInfo type servers. (Although those seem to be busted under current code as well).