### PR TITLE
fix crash when deleting old log files

### DIFF
--- a/BLREdit/App.xaml.cs
+++ b/BLREdit/App.xaml.cs
@@ -269,7 +269,11 @@ public partial class App : System.Windows.Application
             var creationDelta = DateTime.Now - fileInfo.CreationTime;
             if (creationDelta.Days >= 1)
             {
-                fileInfo.Delete();
+                try {
+                    fileInfo.Delete();
+                } catch(Exception e) {
+                    LoggingSystem.Log($"[ERROR] Failed to delete old log file {fileInfo.Name}:\n {e}");
+                }
             }
         }
 


### PR DESCRIPTION
When there is a BLRedit instance running for >1 day spawning another instance will crash because it tries to delete the old log file which is still opened in first instance.
This is a quick-fix by catching the exception when deleting the file, in the long term there should be probably a check if blredit is already running to prevent errors.