### PR TITLE
Update BLRE-NP Staging

### DIFF
--- a/Resources/ServerList.json
+++ b/Resources/ServerList.json
@@ -23,7 +23,7 @@
   },
   {
     "ServerAddress": "blrevive-staging.northamp.fr",
-    "InfoPort": 80,
+    "InfoPort": 7777,
     "Hidden": true,
     "Region": "EU-West",
     "AllowAdvanced": true,


### PR DESCRIPTION
NP Staging server moved to the beta module and uses 7777 UDP & TCP for the game and API respectively (for now)