### PR TITLE
BLRevive update changes

### DIFF
--- a/BLREdit/API/Export/ExportSystem.cs
+++ b/BLREdit/API/Export/ExportSystem.cs
@@ -212,7 +212,31 @@ public sealed class BLRLoadoutStorage(ShareableProfile share, BLRProfile? blr = 
             Directory.CreateDirectory(directory);
             if (client.SDKType == "BLRevive")
             {
-                IOResources.SerializeFile($"{directory}{DataStorage.Settings.PlayerName}.json", new[] { new LMLoadout(BLR.Loadout1, "Loadout 1"), new LMLoadout(BLR.Loadout2, "Loadout 2"), new LMLoadout(BLR.Loadout3, "Loadout 3") });
+                if (DataStorage.Settings.ApplyMergedProfiles.Is)
+                {
+                    List<LMLoadout> loadouts = new List<LMLoadout>();
+
+
+                    int profileIndex = 0;
+                    foreach (var profile in DataStorage.Loadouts)
+                    {
+                        var profileName = DataStorage.ShareableProfiles[profileIndex].Name;
+                        loadouts.Add(new LMLoadout(profile.BLR.Loadout1, $"{profileName} {profile.BLR.Loadout1.Name}"));
+                        loadouts.Add(new LMLoadout(profile.BLR.Loadout2, $"{profileName} {profile.BLR.Loadout2.Name}"));
+                        loadouts.Add(new LMLoadout(profile.BLR.Loadout3, $"{profileName} {profile.BLR.Loadout3.Name}"));
+                        profileIndex++;
+                    }
+
+                    IOResources.SerializeFile($"{directory}{DataStorage.Settings.PlayerName}.json", loadouts.ToArray());
+                }
+                else
+                {
+                    IOResources.SerializeFile($"{directory}{DataStorage.Settings.PlayerName}.json", new[] {
+                        new LMLoadout(BLR.Loadout1, BLR.Loadout1.Name),
+                        new LMLoadout(BLR.Loadout2, BLR.Loadout2.Name),
+                        new LMLoadout(BLR.Loadout3, BLR.Loadout3.Name)
+                    });
+                }
                 MainWindow.ShowAlert($"Applied BLRevive Loadouts!\nScroll through your loadouts to\nrefresh ingame Loadouts!", 8); //TODO: Add Localization
             }
             else

--- a/BLREdit/API/Export/ShareableProfile.cs
+++ b/BLREdit/API/Export/ShareableProfile.cs
@@ -2,7 +2,7 @@
 using BLREdit.Import;
 using BLREdit.UI;
 using BLREdit.UI.Views;
-
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -207,6 +207,7 @@ public sealed class Shareable3LoadoutSet : IBLRProfile
 public sealed class ShareableLoadout : IBLRLoadout
 {
     [JsonIgnore] public ShareableProfile? Profile { get; set; } = null;
+    [JsonPropertyName("Name")] public string Name { get; set; } = String.Empty;
     [JsonPropertyName("R1")] public ShareableWeapon Primary { get; set; } = new();
     [JsonPropertyName("R2")] public ShareableWeapon Secondary { get; set; } = new();
     [JsonPropertyName("F1")] public bool Female { get; set; } = false;
@@ -249,6 +250,7 @@ public sealed class ShareableLoadout : IBLRLoadout
 
     public ShareableLoadout(BLRLoadout loadout, ShareableProfile? profile)
     {
+        Name = loadout.Name;
         Profile = profile;
         Female = loadout.IsFemale;
         BodyCamo = BLRItem.GetMagicCowsID(loadout.BodyCamo);
@@ -301,6 +303,7 @@ public sealed class ShareableLoadout : IBLRLoadout
     {
         var loadout = new BLRLoadout(profile)
         {
+            Name = Name,
             IsFemale = Female,
             IsBot = Bot,
 
@@ -358,6 +361,7 @@ public sealed class ShareableLoadout : IBLRLoadout
     {
         var clone = new ShareableLoadout(null)
         {
+            Name = Name,
             Primary = Primary.Clone(),
             Secondary = Secondary.Clone(),
             Avatar = Avatar,
@@ -411,6 +415,7 @@ public sealed class ShareableLoadout : IBLRLoadout
         if (UndoRedoSystem.CurrentlyBlockedEvents.Value.HasFlag(BlockEvents.ReadLoadout)) return;
         UndoRedoSystem.CurrentlyBlockedEvents.Value = BlockEvents.All;
 
+        loadout.Name = Name.IsNullOrEmpty() ? $"Loadout {Profile?.Loadouts.IndexOf(this) + 1}" : Name;
         loadout.IsFemale = Female;
         loadout.IsBot = Bot;
 
@@ -466,6 +471,7 @@ public sealed class ShareableLoadout : IBLRLoadout
         if (UndoRedoSystem.CurrentlyBlockedEvents.Value.HasFlag(BlockEvents.WriteLoadout)) return;
         if (Profile is not null) { Profile.LastModified = DateTime.Now; }
 
+        Name = loadout.Name;
         Female = loadout.IsFemale;
         Bot = loadout.IsBot;
         Avatar = BLRItem.GetMagicCowsID(loadout.Avatar, -1);

--- a/BLREdit/API/Utils/BLREditSettings.cs
+++ b/BLREdit/API/Utils/BLREditSettings.cs
@@ -48,6 +48,7 @@ public sealed class BLREditSettings : INotifyPropertyChanged
     public UIBool InstallRequiredModules { get; set; } = new(true);
     public UIBool PingHiddenServers { get; set; } = new(true);
     public UIBool ShowHiddenServers { get; set; } = new(false);
+    public UIBool ApplyMergedProfiles { get; set; } = new(true);
     [JsonPropertyName("SelectedProxyVersion")] public string? _selectedSDKType;
     public DateTime? SDKVersionDate { get; set; }
     [JsonIgnore] public string? SelectedSDKType { get { _selectedSDKType ??= AvailableProxyVersions.First(); return _selectedSDKType; } set { if (AvailableProxyVersions.Contains(value)) { _selectedSDKType = value; } } }

--- a/BLREdit/App.xaml.cs
+++ b/BLREdit/App.xaml.cs
@@ -21,6 +21,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Navigation;
 
 namespace BLREdit;
 /// <summary>
@@ -923,6 +924,11 @@ public partial class App : System.Windows.Application
     private static async Task<RepositoryProxyModule[]?> GetAvailableProxyModules()
     {
         LoggingSystem.Log("Downloading AvailableProxyModule List!");
+#if DEBUG
+        var moduleList = IOResources.Deserialize<RepositoryProxyModule[]>(File.ReadAllText("../../../../Resources/ProxyModules.json"));
+        LoggingSystem.Log("Loaded AvailableProxyModule from local file!");
+        return moduleList;
+#else
         try
         {
             if (await GitHubClient.GetFile(CurrentOwner, CurrentRepo, "master", "Resources/ProxyModules.json") is GitHubFile file)
@@ -935,11 +941,17 @@ public partial class App : System.Windows.Application
         catch (Exception error)
         { LoggingSystem.MessageLog($"Can't get ProxyModule list from Github\n{error}", "Error"); } //TODO: Add Localization
         return Array.Empty<RepositoryProxyModule>();
+#endif
     }
 
     private static async Task<Dictionary<string, string>?> GetAvailableLocalizations()
     {
         LoggingSystem.Log("Downloading AvailableLocalization List!");
+#if DEBUG
+        var localizations = IOResources.Deserialize<Dictionary<string, string>>(File.ReadAllText("../../../../Resources/Localizations.json"));
+        LoggingSystem.Log("Loaded AvailableLocalizations from local file!");
+        return localizations;
+#else
         try
         {
             if (await GitHubClient.GetFile(CurrentOwner, CurrentRepo, "master", "Resources/Localizations.json") is GitHubFile file)
@@ -952,11 +964,18 @@ public partial class App : System.Windows.Application
         catch (Exception error)
         { LoggingSystem.MessageLog($"Can't get Localization list from Github\n{error}", "Error"); } //TODO: Add Localization
         return new();
+#endif
     }
 
     private static async Task<List<BLRServer>?> GetDefaultServers()
     {
         LoggingSystem.Log($"Downloading Default Server List!");
+
+#if DEBUG
+        var servers = IOResources.Deserialize<List<BLRServer>>(File.ReadAllText("../../../../Resources/ServerList.json"));
+        LoggingSystem.Log("Loaded Available Servers from local file!");
+        return servers;
+#else
         try
         {
             if (await GitHubClient.GetFile(CurrentOwner, CurrentRepo, "master", "Resources/ServerList.json") is GitHubFile file)
@@ -972,6 +991,7 @@ public partial class App : System.Windows.Application
         { //Only localhost is needed as most likely we are offline so there is no need to add anyother default servers
             new() { ServerAddress = "localhost", Port = 7777 } //Local User Server
         };
+#endif
     }
 
     public static Task<T> StartSTATask<T>(Func<T> action)

--- a/BLREdit/Game/BLRClient.cs
+++ b/BLREdit/Game/BLRClient.cs
@@ -693,7 +693,7 @@ public sealed class BLRClient : INotifyPropertyChanged
     {
         (var mode, var map, var canceled) = MapModeSelect.SelectMapAndMode(this.ClientVersion);
         if (canceled) { LoggingSystem.Log($"Canceled Botmatch Launch"); return; }
-        string launchArgs = $"server {map?.MapName ?? "helodeck"}{(string.IsNullOrEmpty(ConfigName) ? "" : $"?config={ConfigName}-Server")}?Game=FoxGame.FoxGameMP_{mode?.ModeName ?? "DM"}?ServerName=BLREdit-{mode?.ModeName ?? "DM"}-Server?Port=7777?NumBots={DataStorage.Settings.BotCount}?MaxPlayers={DataStorage.Settings.PlayerCount}";
+        string launchArgs = $"server {map?.MapName ?? "helodeck"}{(string.IsNullOrEmpty(ConfigName) ? "" : $"?config={ConfigName}-Server")}?Game=FoxGame.FoxGameMP_{mode?.ModeName ?? "DM"}?ServerName=BLREdit-{mode?.ModeName ?? "DM"}-Server?Port=7777?NumBots={DataStorage.Settings.BotCount}?MaxPlayers={DataStorage.Settings.PlayerCount}?blre.server.authenticateusers=false";
         StartProcess(launchArgs, true, DataStorage.Settings.ServerWatchDog.Is);
         LaunchClient(new LaunchOptions() { UserName = DataStorage.Settings.PlayerName, Server = LocalHost });
     }

--- a/BLREdit/Game/Proxy/ProxyModule.cs
+++ b/BLREdit/Game/Proxy/ProxyModule.cs
@@ -10,7 +10,7 @@ namespace BLREdit.Game.Proxy;
 
 public sealed class ProxyModule
 {
-    public string InstallName { get { return $"{PackageFileName}-{Owner}-{Repository}".Replace('/', '-'); } }
+    public string InstallName { get { return $"{PackageFileName}"; } }
     public string Owner { get; set; } = "blrevive";
     public string Repository { get; set; } = "modules/loadout-manager";
     public string ModuleName { get; set; } = "LoadoutManager";

--- a/BLREdit/Game/Proxy/RepositoryProxyModule.cs
+++ b/BLREdit/Game/Proxy/RepositoryProxyModule.cs
@@ -18,7 +18,7 @@ namespace BLREdit.Game.Proxy;
 public sealed class RepositoryProxyModule
 {
     public RepositoryProvider RepositoryProvider { get; set; } = RepositoryProvider.Gitlab;
-    [JsonIgnore] public string InstallName { get { return $"{PackageFileName}-{Owner}-{Repository}".Replace('/', '-'); } }
+    [JsonIgnore] public string InstallName { get { return $"{PackageFileName}"; } }
     public string Owner { get; set; } = "blrevive";
     public string Repository { get; set; } = "modules/loadout-manager";
     public string ModuleName { get; set; } = "LoadoutManager";

--- a/BLREdit/UI/Controls/BLREditSettingsControl.xaml
+++ b/BLREdit/UI/Controls/BLREditSettingsControl.xaml
@@ -105,6 +105,11 @@
                         <ToggleButton Content="{x:Static p:Resources.tbtn_ShowHiddenServers }" ToolTip="{x:Static p:Resources.tbtn_TT_ShowHiddenServers }" IsChecked="{Binding Path=Is, Mode=TwoWay}"/>
                 </StackPanel>
             </Border>
+            <Border>
+                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Stretch" Height="32" DataContext="{Binding Path=ApplyMergedProfiles}">
+                    <ToggleButton Content="Apply Merged Profiles" IsChecked="{Binding Path=Is, Mode=TwoWay}"/>
+                </StackPanel>
+            </Border>
 
             <Border>
                 <StackPanel Orientation="Horizontal" VerticalAlignment="Top" HorizontalAlignment="Stretch" Height="32">

--- a/BLREdit/UI/Views/BLRLoadout.cs
+++ b/BLREdit/UI/Views/BLRLoadout.cs
@@ -28,6 +28,9 @@ public sealed class BLRLoadout : INotifyPropertyChanged
     public BLRWeapon Secondary { get; set; }
 
     private bool isChanged = false;
+    
+    private string name = "";
+    public string Name { get { return name; } set { name = value; Write(); } }
     [JsonIgnore] public bool IsChanged { get { return isChanged; } set { isChanged = value; OnPropertyChanged(); } }
 
     private void ItemChanged([CallerMemberName] string? propertyName = null)

--- a/BLREdit/UI/Windows/MainWindow.xaml
+++ b/BLREdit/UI/Windows/MainWindow.xaml
@@ -29,13 +29,22 @@
         <Button Width="120" Height="22" Margin="270,35,0,0" Name="RandomLoadout" Content="{x:Static p:Resources.btn_RandomizeLoadout}" HorizontalAlignment="Left"  VerticalAlignment="Top"  Click="RandomLoadout_Click"/>
 
         <TabControl Name="LoadoutTabs" BorderThickness="0,1,0,0" HorizontalAlignment="Left" Width="420" Margin="0,64,0,0" SelectionChanged="LoadoutTabs_SelectionChanged" DataContext="{Binding Path=Profile.BLR}">
-            <TabItem Header="{x:Static p:Resources.ti_Loadout1}" Name="Loadout1Tab">
+            <TabItem Name="Loadout1Tab">
+                <TabItem.Header>
+                    <TextBox x:Name="Loadout1Name" Text="{Binding Path=Loadout1.Name}" Width="102" BorderThickness="0" Height="17" Background="Transparent"/>
+                </TabItem.Header>
                 <ui:LoadoutControl x:Name="Loadout1" DataContext="{Binding Path=Loadout1}" x:FieldModifier="public" Border.DragEnter="Border_DragEnter" Border.Drop="Border_Drop" Border.MouseUp="Border_MouseUp"/>
             </TabItem>
-            <TabItem Header="{x:Static p:Resources.ti_Loadout2}" Name="Loadout2Tab">
+            <TabItem Name="Loadout2Tab">
+                <TabItem.Header>
+                    <TextBox x:Name="Loadout2Name" Text="{Binding Path=Loadout2.Name}" Width="102" BorderThickness="0" Height="17" Background="Transparent"/>
+                </TabItem.Header>
                 <ui:LoadoutControl x:Name="Loadout2" DataContext="{Binding Path=Loadout2}" x:FieldModifier="public" Border.DragEnter="Border_DragEnter" Border.Drop="Border_Drop" Border.MouseUp="Border_MouseUp"/>
             </TabItem>
-            <TabItem Header="{x:Static p:Resources.ti_Loadout3}" Name="Loadout3Tab">
+            <TabItem Name="Loadout3Tab">
+                <TabItem.Header>
+                    <TextBox x:Name="Loadout3Name" Text="{Binding Path=Loadout3.Name}" Width="102" BorderThickness="0" Height="17" Background="Transparent"/>
+                </TabItem.Header>
                 <ui:LoadoutControl x:Name="Loadout3" DataContext="{Binding Path=Loadout3}" x:FieldModifier="public" Border.DragEnter="Border_DragEnter" Border.Drop="Border_Drop" Border.MouseUp="Border_MouseUp"/>
             </TabItem>
         </TabControl>

--- a/BLREdit/UI/Windows/MainWindow.xaml.cs
+++ b/BLREdit/UI/Windows/MainWindow.xaml.cs
@@ -553,7 +553,31 @@ public sealed partial class MainWindow : Window
     {
         var directory = $"{client.ConfigFolder}profiles\\";
         Directory.CreateDirectory(directory);
-        IOResources.SerializeFile($"{directory}{DataStorage.Settings.PlayerName}.json", new[] { new LMLoadout(MainView.Profile.BLR.Loadout1, "Loadout 1"), new LMLoadout(MainView.Profile.BLR.Loadout2, "Loadout 2"), new LMLoadout(MainView.Profile.BLR.Loadout3, "Loadout 3") });
+        if (DataStorage.Settings.ApplyMergedProfiles.Is)
+        {
+            List<LMLoadout> loadouts = new List<LMLoadout>();
+
+            
+            int profileIndex = 0;
+            foreach (var profile in DataStorage.Loadouts)
+            {
+                var profileName = DataStorage.ShareableProfiles[profileIndex].Name;
+                loadouts.Add(new LMLoadout(profile.BLR.Loadout1, $"{profileName} {profile.BLR.Loadout1.Name}"));
+                loadouts.Add(new LMLoadout(profile.BLR.Loadout2, $"{profileName} {profile.BLR.Loadout2.Name}"));
+                loadouts.Add(new LMLoadout(profile.BLR.Loadout3, $"{profileName} {profile.BLR.Loadout3.Name}"));
+                profileIndex++;
+            }
+
+            IOResources.SerializeFile($"{directory}{DataStorage.Settings.PlayerName}.json", loadouts.ToArray());
+        }
+        else
+        {
+            IOResources.SerializeFile($"{directory}{DataStorage.Settings.PlayerName}.json", new[] { 
+                new LMLoadout(MainView.Profile.BLR.Loadout1, MainView.Profile.BLR.Loadout1.Name), 
+                new LMLoadout(MainView.Profile.BLR.Loadout2, MainView.Profile.BLR.Loadout2.Name), 
+                new LMLoadout(MainView.Profile.BLR.Loadout3, MainView.Profile.BLR.Loadout3.Name) 
+            });
+        }
         ShowAlert($"Applied BLRevive Loadouts!\nScroll through your loadouts to\nrefresh ingame Loadouts!", 8); //TODO: Add Localization
     }
 

--- a/Resources/ProxyModules.json
+++ b/Resources/ProxyModules.json
@@ -26,5 +26,36 @@
     "Client": false,
     "Required": true,
     "ProxyVersion": "BLRevive"
+  },
+
+
+
+
+  {
+    "RepositoryProvider": "Gitlab",
+    "Owner": "Kethen",
+    "Repository": "loadout-manager",
+    "ModuleName": "LoadoutManager",
+    "Server": false,
+    "Required": true,
+    "ProxyVersion": "v1.0.0-beta.2"
+  },
+  {
+    "RepositoryProvider": "GitHub",
+    "Owner": "Kethen",
+    "Repository": "BLRE-settings-manager",
+    "ModuleName": "settings-manager",
+    "Server": false,
+    "Required": true,
+    "ProxyVersion": "v1.0.0-beta.2"
+  },
+  {
+    "RepositoryProvider": "GitHub",
+    "Owner": "Kethen",
+    "Repository": "BLRE-server-utils",
+    "ModuleName": "server-utils",
+    "Client": false,
+    "Required": true,
+    "ProxyVersion": "v1.0.0-beta.2"
   }
 ]


### PR DESCRIPTION
This PR includes:

- *feature*: exporting merged profiles (all loadouts into a single file) as requested in #101 
- *feature*: changing loadout names
- *fix*: using plain module names for files and config (#99)
- *fix*: adding `blre.server.authenticateusers=false` to bot match url to disable user authentication
- *refactor*: use local resources while debugging to reflect changes 

![BLReditLoadoutNamesAndMerge](https://github.com/HALOMAXX/BLREdit/assets/34782055/734dd652-a900-49e2-acfc-9c9700a65288)
